### PR TITLE
fix: 帖子详情页暗色样式适配主题切换

### DIFF
--- a/forum/templates/forum/post_detail.html
+++ b/forum/templates/forum/post_detail.html
@@ -117,22 +117,20 @@
         border-radius: 6px;
     }
 
-    @media (prefers-color-scheme: dark) {
-        .post-meta {
-            border-bottom-color: #30363d;
-        }
+    [data-bs-theme="dark"] .post-meta {
+        border-bottom-color: #30363d;
+    }
 
-        .comment-item {
-            background-color: rgba(255, 255, 255, 0.05);
-        }
+    [data-bs-theme="dark"] .comment-item {
+        background-color: rgba(255, 255, 255, 0.05);
+    }
 
-        .comment-item:hover {
-            background-color: rgba(255, 255, 255, 0.08);
-        }
+    [data-bs-theme="dark"] .comment-item:hover {
+        background-color: rgba(255, 255, 255, 0.08);
+    }
 
-        .comment-form {
-            background-color: rgba(255, 255, 255, 0.05);
-        }
+    [data-bs-theme="dark"] .comment-form {
+        background-color: rgba(255, 255, 255, 0.05);
     }
 </style>
 


### PR DESCRIPTION
## Summary
- 将 `post_detail.html` 中的暗色样式从 `@media (prefers-color-scheme: dark)` 改为 `[data-bs-theme="dark"]` 选择器
- 与 #18 主题切换功能保持一致，手动切换暗色模式时样式也能正确生效