### PR TITLE
fix: 修复6个P2级Bug(评分校验/合集分页/机器人健壮性/查询稳定性)

### DIFF
--- a/forum/bots/bot.py
+++ b/forum/bots/bot.py
@@ -5,4 +5,4 @@ class BotBase():
         self.id = id
 
     def handler(self, context):
-        self.manager.send_comment(context.get(id), self.id, "Hello! I'm bot base.")
+        self.manager.send_comment(context.get("id"), self.id, "Hello! I'm bot base.")

--- a/forum/bots_manager.py
+++ b/forum/bots_manager.py
@@ -35,10 +35,16 @@ class BotsManager():
     @staticmethod
     def send_comment(post_id, id, message):
         with transaction.atomic():
+            try:
+                post = Post.objects.get(id=post_id)
+                author = User.objects.get(id=id)
+            except (Post.DoesNotExist, User.DoesNotExist):
+                # 帖子已被删除或机器人账号不存在，静默跳过
+                return
             Comment.objects.create(
-                post = Post.objects.get(id=post_id),
-                author = User.objects.get(id=id),
-                content = message
+                post=post,
+                author=author,
+                content=message
             )
 
 manager = BotsManager()

--- a/forum/templates/forum/collection_detail.html
+++ b/forum/templates/forum/collection_detail.html
@@ -43,4 +43,18 @@
       <li class="list-group-item">合集中暂无文章</li>
     {% endfor %}
   </ol>
+
+  {% if page_obj.has_other_pages %}
+  <nav class="pagination mt-3" aria-label="合集文章分页">
+    <ul class="pagination justify-content-center">
+      {% if page_obj.has_previous %}
+        <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">上一页</a></li>
+      {% endif %}
+      <li class="page-item disabled"><span class="page-link">第 {{ page_obj.number }} 页 / 共 {{ page_obj.paginator.num_pages }} 页</span></li>
+      {% if page_obj.has_next %}
+        <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">下一页</a></li>
+      {% endif %}
+    </ul>
+  </nav>
+  {% endif %}
 {% endblock %}

--- a/forum/templates/forum/collection_list.html
+++ b/forum/templates/forum/collection_list.html
@@ -24,4 +24,18 @@
       <li class="list-group-item">暂无合集</li>
     {% endfor %}
   </ul>
+
+  {% if page_obj.has_other_pages %}
+  <nav class="pagination mt-3" aria-label="合集分页">
+    <ul class="pagination justify-content-center">
+      {% if page_obj.has_previous %}
+        <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">上一页</a></li>
+      {% endif %}
+      <li class="page-item disabled"><span class="page-link">第 {{ page_obj.number }} 页 / 共 {{ page_obj.paginator.num_pages }} 页</span></li>
+      {% if page_obj.has_next %}
+        <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">下一页</a></li>
+      {% endif %}
+    </ul>
+  </nav>
+  {% endif %}
 {% endblock %}

--- a/forum/views.py
+++ b/forum/views.py
@@ -28,7 +28,7 @@ from forum.bots_manager import manager
 
 def index(request):
     items = Item.objects.all()
-    posts = Post.objects.all()[:6]
+    posts = Post.objects.order_by('-created_at')[:6]
     post_count = Post.objects.count()
     return render(request, 'forum/index.html', {'items': items, 'posts' : posts, 'post_count': post_count})
 
@@ -46,7 +46,14 @@ class PostListView(ListView):
 def rate_item(request, item_id):
     item = get_object_or_404(Item, id=item_id)
     if request.method == 'POST':
-        score = int(request.POST.get('score'))
+        try:
+            score = int(request.POST.get('score', ''))
+        except (TypeError, ValueError):
+            messages.error(request, '评分必须是 1-5 之间的整数。')
+            return redirect('rate_item', item_id=item.id)
+        if not 1 <= score <= 5:
+            messages.error(request, '评分必须在 1-5 之间。')
+            return redirect('rate_item', item_id=item.id)
         Rating.objects.update_or_create(
             user=request.user,
             item=item,
@@ -232,8 +239,13 @@ def about_view(request):
 # ---- Collection views ----
 
 def collection_list(request):
-    collections = Collection.objects.all()
-    return render(request, 'forum/collection_list.html', {'collections': collections})
+    collections = Collection.objects.select_related('owner').all()
+    paginator = Paginator(collections, 20)
+    page_obj = paginator.get_page(request.GET.get('page', 1))
+    return render(request, 'forum/collection_list.html', {
+        'collections': page_obj,
+        'page_obj': page_obj,
+    })
 
 
 @login_required
@@ -250,9 +262,12 @@ def collection_create(request):
 def collection_detail(request, collection_id):
     collection = get_object_or_404(Collection, id=collection_id)
     posts = collection.collection_posts.select_related('post', 'post__author').all()
+    paginator = Paginator(posts, 20)
+    page_obj = paginator.get_page(request.GET.get('page', 1))
     return render(request, 'forum/collection_detail.html', {
         'collection': collection,
-        'collection_posts': posts,
+        'collection_posts': page_obj,
+        'page_obj': page_obj,
     })
 
 


### PR DESCRIPTION
## 背景

延续 #42 (P0) 与 #43 (P1) 后的 P2 级别 Bug 修复。本 PR 聚焦**输入校验、分页缺失、机器人健壮性、查询稳定性**等中等优先级问题，所有修复均通过测试。

## 修复清单

| # | 文件 | 问题 | 修复 |
|---|------|------|------|
| 1 | `forum/views.py` `rate_item` | 评分接口直接 `int(score)`，非数字输入触发 `ValueError` 返回 500 | 增加 try/except 类型转换 + 1-5 范围校验，非法输入重定向并 `messages.error` 提示 |
| 2 | `forum/views.py` `collection_list` | `Collection.objects.all()` 无分页，数据量大时单页渲染性能差 | `Paginator` 每页 20 条 + `select_related('owner')` 减少 N+1 查询 |
| 3 | `forum/views.py` `collection_detail` | 合集内文章无分页 | `Paginator` 每页 20 条，`select_related('post', 'post__author')` 优化 |
| 4 | `forum/bots_manager.py` `send_comment` | 帖子被删除后 bot 回复触发 `Post.DoesNotExist`，线程崩溃 | `try/except` 捕获 `Post.DoesNotExist / User.DoesNotExist` 静默跳过 |
| 5 | `forum/views.py` `index` | `Post.objects.all()[:6]` 未显式排序，依赖模型 Meta，跨查询行为不稳定 | 改为 `order_by('-created_at')[:6]` 显式排序 |
| 6 | `forum/bots/bot.py` `BotBase.handler` | `context.get(id)` 误用内置函数 `id` 作为键，永远返回 `None` | 改为字符串键 `context.get("id")` |

## 模板改动

- `collection_list.html` / `collection_detail.html`：新增分页导航（上一页 / 当前页/总页数 / 下一页）

## 测试

```
$ python manage.py test
Creating test database for alias 'default'...
............
----------------------------------------------------------------------
Ran 12 tests in 47.499s

OK
```

全部 12 个测试通过。

## 说明

- P2 修复均不涉及安全漏洞，但显著提升健壮性与可维护性
- 无新增依赖，无数据库迁移
- 建议在 #42 / #43 合并后合并本 PR，避免冲突
